### PR TITLE
test : Added test for cvtTimeToMinutes error

### DIFF
--- a/__tests__/etl/timeProcess.ts
+++ b/__tests__/etl/timeProcess.ts
@@ -36,5 +36,12 @@ describe('Time Processor Modules', () => {
 
 			done()
 		})
+
+		it('Should throw an error if time input is not formatted as HH:MM', (done) => {
+			const invalidInput = '01PM'
+
+			expect(() => cvtTimeToMinutes(invalidInput)).to.throw()
+			done()
+		})
 	})
 })


### PR DESCRIPTION
Added test to check whether cvtTimeToMinutes function throws an error when input data is not in `HH:MM` format. 